### PR TITLE
Rename arm.move_to_pose() interface for consistency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>robot_api</name>
-  <version>1.8.0</version>
+  <version>1.9.0</version>
   <description>A pre- and concise Python API to control robots with simple commands.</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->

--- a/robot_api/extensions.py
+++ b/robot_api/extensions.py
@@ -158,7 +158,7 @@ class Arm(ActionlibComponent):
         """
         return self._call_moveit_macro("target", pose_name, done_cb)
 
-    def move_to_position(self, pose: Pose) -> None:
+    def move_to_pose(self, pose: Pose) -> None:
         """
         Move arm endeffector to pose using the MoveIt Commander.
         """

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="robot_api",
-    version="1.8.0",
+    version="1.9.0",
     description="A pre- and concise Python API to control robots with simple commands.",
     author="Alexander Sung",
     author_email="Alexander.Sung@dfki.de",


### PR DESCRIPTION
Dear @brean, this is just a small change but since it probably is an interface change for you at potentially several places, here's a pull request for changing the method `move_to_position()` to `move_to_pose()`. I didn't notice it before but would like to address this rather sooner than later.

Talking about this interface, I just mention that I considered merging this method into `move()` as overloaded methods - but so far it doesn't seem meaningful (apart from the common name) because the parameters are different. I'm open to this if you would indeed prefer to call `move(pose=pose)`.