### PR TITLE
Fix namespace-string should be f-string.

### DIFF
--- a/robot_api/extensions.py
+++ b/robot_api/extensions.py
@@ -52,8 +52,8 @@ class Arm(ActionlibComponent):
             {
                 self.MOVEIT_MACROS_TOPIC_NAME: (
                     MoveItMacroAction,
-                    f"roslaunch robot_api moveit_macros.launch"
-                    " namespace:='{namespace.strip('/')}'",
+                    "roslaunch robot_api moveit_macros.launch"
+                    f" namespace:='{namespace.strip('/')}'",
                     self.ROSLAUNCH_SLEEP_DURATION,
                 ),
                 self.FT_OBSERVER_TOPIC_NAME: (FtObserverAction,),


### PR DESCRIPTION
During start you will see this error, it should be fixed with this PR:
```
[INFO] [1682068400.312377, 0.713000]: roslaunch robot_api moveit_macros.launch namespace:='{namespace.strip('/')}'
RLException: error loading <rosparam> tag: 
	file /root/catkin_ws/src/robot_api/config/kinematics.yaml contains invalid YAML:
while parsing a block mapping
  in "<unicode string>", line 2, column 3:
      kinematics_solver: trac_ik_kinem ... 
      ^
expected <block end>, but found '<scalar>'
  in "<unicode string>", line 10, column 35:
      arm_prefix: {namespace.strip(/)}/ur5_
                                      ^
XML is <rosparam command="load" file="$(find robot_api)/config/kinematics.yaml" subst_value="true"/>
The traceback for the exception was written to the log file
```